### PR TITLE
Add Docker test environment and fix bugs in experiment scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+C++/build/
+expts/tmp/
+**/__pycache__/
+**/*.pyc
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# ── Stage 1: Build C++ binary ─────────────────────────────────────────────
+FROM ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build VXL (provides vnl/vnl_algo/vcl)
+RUN git clone --depth 1 https://github.com/vxl/vxl.git /vxl-src && \
+    cmake -B /vxl-build -S /vxl-src \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DBUILD_DOCUMENTATION=OFF \
+        -DVXL_BUILD_EXAMPLES=OFF && \
+    cmake --build /vxl-build --parallel $(nproc)
+
+ENV VXL_DIR=/vxl-build
+
+COPY C++/ /workspace/C++/
+WORKDIR /workspace/C++
+RUN cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --parallel $(nproc)
+
+
+# ── Stage 2: Python test environment ──────────────────────────────────────
+FROM python:3.12-slim AS runner
+
+# System libraries required by open3d and opencv-python
+RUN apt-get update && apt-get install -y \
+    libgomp1 \
+    libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only the compiled binary into the path the Python scripts expect
+# (expts/ scripts resolve BINARY_DIR as '../C++/build' relative to /workspace/expts)
+COPY --from=builder /workspace/C++/build/gmmreg_demo /workspace/C++/build/gmmreg_demo
+
+# Install Python dependencies (expts/ is mounted at runtime, not copied)
+COPY expts/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --root-user-action=ignore -r /tmp/requirements.txt
+
+# Mount expts/ at runtime: docker run -v $(PWD)/expts:/workspace/expts
+WORKDIR /workspace/expts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+IMAGE   ?= gmmreg-expts
+DRAGON_DATA ?= $(PWD)/data/dragon_stand
+LOUNGE_DATA ?= $(PWD)/data/lounge
+
+.PHONY: build run-dragon run-lounge shell clean
+
+build:
+	docker build -t $(IMAGE) .
+
+run-dragon: build
+	docker run --rm \
+		-v $(PWD)/expts:/workspace/expts \
+		-v $(DRAGON_DATA):/workspace/data/dragon_stand:ro \
+		$(IMAGE) \
+		python dragon_expts.py --data_dir /workspace/data/dragon_stand $(ARGS)
+
+run-lounge: build
+	docker run --rm \
+		-v $(PWD)/expts:/workspace/expts \
+		-v $(LOUNGE_DATA):/workspace/data/lounge:ro \
+		$(IMAGE) \
+		python lounge_expts.py --data_path /workspace/data/lounge $(ARGS)
+
+shell: build
+	docker run --rm -it \
+		-v $(PWD)/expts:/workspace/expts \
+		-v $(DRAGON_DATA):/workspace/data/dragon_stand:ro \
+		-v $(LOUNGE_DATA):/workspace/data/lounge:ro \
+		$(IMAGE) bash
+
+clean:
+	docker rmi $(IMAGE)

--- a/expts/README.md
+++ b/expts/README.md
@@ -1,0 +1,189 @@
+# GMM Registration — Experiment Scripts
+
+These scripts reproduce the point cloud registration experiments from the gmmreg PAMI paper using the `gmmreg_demo` binary.
+
+## Running with Docker (recommended)
+
+A multi-stage `Dockerfile` at the repo root builds the C++ binary and sets up a Python 3.12 environment in one step.
+
+```bash
+# From the repo root — data paths default to ./data/dragon_stand and ./data/lounge
+make run-dragon
+make run-lounge
+
+# Override data paths
+make run-dragon DRAGON_DATA=/path/to/dragon_stand
+make run-lounge LOUNGE_DATA=/path/to/lounge
+
+# Pass extra script arguments
+make run-dragon ARGS="--intervals 1,2 --voxel_size 0.003"
+
+# Build image only
+make build
+
+# Drop into a shell inside the container for debugging
+make shell
+
+# Remove the image
+make clean
+```
+
+> **Note:** `--visualize` flags require a display and will not work inside the container. Run visualizations locally instead.
+
+---
+
+## Prerequisites (running locally)
+
+### 1. Build the binary
+
+The scripts expect the compiled binary at `../C++/build/gmmreg_demo` (Linux/macOS) or `../C++/build/gmmreg_demo.exe` (Windows). Follow the build instructions in the top-level README before proceeding.
+
+### 2. Install Python dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+Python 3.12 is recommended. open3d does not support Python 3.13+.
+
+---
+
+## Experiment 1 — Stanford Dragon Stand
+
+Reproduces Section 6.1 of the gmmreg PAMI paper. The dataset contains 15 scans of a dragon figurine taken at 24-degree intervals (0°, 24°, ..., 336°). The script runs all pairwise rigid registrations for pairs separated by 1, 2, and 3 steps (24°, 48°, 72°) and reports rotation errors.
+
+### Get the dataset
+
+Download the Stanford Dragon Stand dataset:
+- URL: http://graphics.stanford.edu/data/3Dscanrep/
+- Extract so that the PLY files and `dragonStandRight.conf` are under `../data/dragon_stand/`.
+
+Expected layout:
+```
+../data/dragon_stand/
+    dragonStandRight.conf
+    dragonStandRight_0.ply
+    dragonStandRight_24.ply
+    ...
+    dragonStandRight_336.ply
+```
+
+### Run
+
+```bash
+python dragon_expts.py
+```
+
+With all options explicit:
+
+```bash
+python dragon_expts.py \
+    --data_dir ../data/dragon_stand \
+    --config_tmpl ./dragon_stand.ini \
+    --working_dir ./dragon_output \
+    --voxel_size 0.005 \
+    --intervals 1,2,3
+```
+
+To also visualize an example result after registration:
+
+```bash
+python dragon_expts.py --intervals 1 --visualize
+```
+
+### Key arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--data_dir` | `../data/dragon_stand` | Directory with PLY files and ground truth conf |
+| `--config_tmpl` | `./dragon_stand.ini` | gmmreg config template |
+| `--working_dir` | auto (UUID under `/tmp`) | Output directory for results |
+| `--voxel_size` | `0.005` | Voxel size for downsampling PLY files |
+| `--intervals` | `1,2,3` | Step sizes to test (1=24°, 2=48°, 3=72°, 4=96°) |
+| `--gmmreg_exe` | auto-detected | Path to `gmmreg_demo` binary |
+| `--visualize` | off | Show an example registration result with Open3D |
+
+### Expected output
+
+For each step size the script prints rotation error statistics across all 15 pairs:
+
+```
+Summary stats for registering pairs that are 24 degrees away from each other:
+<avg_score, min_score, max_score, median_score>: ...
+<# of high accuracy scores (>.99)>: N out of 15)
+<avg_err, min_err, max_err, median_err>: ..., ..., ..., ... (in degrees)
+<# of small errors (<3 degree)>: N out of 15)
+```
+
+---
+
+## Experiment 2 — Stanford Lounge (RGB-D)
+
+Tests pairwise rigid registration on consecutive RGB-D frames from an indoor scene. Depth images are converted to point clouds and registered with gmmreg.
+
+### Get the dataset
+
+```bash
+wget https://github.com/isl-org/open3d_downloads/releases/download/20220301-data/LoungeRGBDImages.zip
+unzip LoungeRGBDImages.zip -d ../data/lounge
+```
+
+Expected layout after extraction:
+```
+../data/lounge/
+    lounge_trajectory.log
+    depth/
+        000001.png
+        000002.png
+        ...
+        003000.png
+```
+
+### Run
+
+To register and visualize a single pair:
+
+```bash
+python lounge_expts.py                              # uses default ../data/lounge
+python lounge_expts.py --data_path /your/data/path
+```
+
+By default (see `__main__` block) this registers frames 1 and 11, then runs the full batch over all 2995 consecutive-5 pairs.
+
+To change the pair or disable the full batch, edit the `__main__` block at the bottom of `lounge_expts.py`:
+
+```python
+# Register one pair with visualization
+run_pairwise_registration(1, 11, visualize=True)
+
+# Run full batch (2995 pairs, takes a while)
+main()
+```
+
+### Expected output
+
+```
+Input pairs with pose difference ~= X.XX degrees
+<avg_err, min_err, max_err, median_err>: ..., ..., ..., ... (in degrees)
+<# of small errors (<3 degree)>: N out of 2995)
+Registration time: <avg_time, min_time, max_time, median_time>: ... (in milliseconds)
+```
+
+Full batch results are saved to `./tmp/loung_expts_results.txt`.
+
+---
+
+## Output files
+
+Both scripts write intermediate and final results under a `./tmp/` directory (created automatically):
+
+| File | Contents |
+|---|---|
+| `tmp/model.txt` | Downsampled model point cloud (input to binary) |
+| `tmp/scene.txt` | Downsampled scene point cloud (input to binary) |
+| `tmp/final_rigid.txt` | Registration parameters `[q0 q1 q2 q3 tx ty tz]` |
+| `tmp/final_rigid_matrix.txt` | 4×4 rigid transformation matrix |
+| `tmp/transformed_model.txt` | Model after applying the estimated transform |
+| `tmp/elapsed_time_in_ms.txt` | Core registration time reported by the binary |
+
+For the dragon batch experiments, per-pair results are written to subdirectories under `--working_dir` named `{i}_vs_{j}/`.

--- a/expts/common_utils.py
+++ b/expts/common_utils.py
@@ -25,7 +25,7 @@ def downsampled_subset(x, num):
 
 # Run pairwise rigid registration using specified binary and configuration.
 def run_rigid_pairwise(gmmreg_exe, model, scene, f_config):
-    if type(model) == type('abc'):
+    if isinstance(model, str):
         model = np.loadtxt(model)
         scene = np.loadtxt(scene)
     if model.shape[0] > 5000:

--- a/expts/dragon_expts.py
+++ b/expts/dragon_expts.py
@@ -5,16 +5,19 @@ This Python script can be used to test the gmmreg algorithm on the Stanford
 "dragon stand" dataset as described in Section 6.1 of the gmmreg PAMI paper.
 """
 
-import collections, copy, os, subprocess, time
+import argparse
+import base64
+import collections
+import copy
+import os
+import subprocess
+import time
+import uuid
 
 import numpy as np
+from configparser import ConfigParser
 from scipy.spatial.transform import Rotation
 import open3d as o3d
-
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser  # ver. < 3.0
 
 DATA_PATH = '../data/dragon_stand'
 CONFIG_FILE = './dragon_stand.ini'
@@ -45,7 +48,7 @@ def lookup_ground_truth(gt_poses, i, j):
     q_i = Rotation.from_quat(pose_i[3::])
     q_j = Rotation.from_quat(pose_j[3::])
     q_ji = (q_i * q_j.inv()).as_quat()
-    q_ij = (q_i * q_i.inv()).as_quat()
+    q_ij = (q_j * q_i.inv()).as_quat()
     return q_ij, q_ji
 
 
@@ -250,8 +253,6 @@ def main(args):
         batch_processor.visualize()
 
 
-import argparse
-import uuid, base64
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Testing scrpt for running gmmreg on Dragonstand dataset.')

--- a/expts/lounge_expts.py
+++ b/expts/lounge_expts.py
@@ -2,11 +2,18 @@
 #coding=utf-8
 """
 This Python script can be used to test the gmmreg algorithm on the Stanford
-"lounge" dataset.  For how to get this dataset, please refert to
+"lounge" dataset.  For how to get this dataset, please refer to
 http://qianyi.info/scenedata.html
+
+Dataset can be downloaded with:
+  wget https://github.com/isl-org/open3d_downloads/releases/download/20220301-data/LoungeRGBDImages.zip
 """
 
-import copy, os, subprocess, time
+import argparse
+import copy
+import os
+import subprocess
+import time
 
 import cv2
 import numpy as np
@@ -18,14 +25,22 @@ BINARY_DIR = '../C++/build'
 GMMREG_BINARY = {'nt': r'gmmreg_demo.exe', 'posix': r'gmmreg_demo'}
 
 BINARY_FULLPATH = os.path.join(BINARY_DIR, GMMREG_BINARY[os.name])
-TRAJECTORY_PATH = '../data/lounge/lounge_trajectory.log'
 TMP_PATH = './tmp'
 CONFIG_FILE = './lounge.ini'
-# Change DATA_PATH to where rgb-d data are located.
-DATA_PATH = '/home/bing/data/lounge'
 
 if not os.path.exists(TMP_PATH):
     os.makedirs(TMP_PATH)
+
+# Populated by _init_data() before any registration calls.
+GT_POS = None
+DEPTH_FILES = None
+
+
+def _init_data(data_path):
+    global GT_POS, DEPTH_FILES
+    trajectory_path = os.path.join(data_path, 'lounge_trajectory.log')
+    GT_POS = parse_ground_truth(trajectory_path)
+    DEPTH_FILES = get_all_depth_files(data_path)
 
 
 def parse_ground_truth(trajectory_conf):
@@ -39,15 +54,9 @@ def parse_ground_truth(trajectory_conf):
     return matrices
 
 
-GT_POS = parse_ground_truth(TRAJECTORY_PATH)
-
-
 def get_all_depth_files(data_path):
     ind = range(1, 3001)
     return [os.path.join(data_path, 'depth/%06d.png' % j) for j in ind]
-
-
-DEPTH_FILES = get_all_depth_files(DATA_PATH)
 
 
 def draw_registration_result(source, target, transformation):
@@ -100,10 +109,10 @@ def run_pairwise_registration(i, j, visualize=False, icp_refine=False):
     pcloud_transformed = o3d.geometry.PointCloud()
     pcloud_transformed.points = o3d.utility.Vector3dVector(transformed)
     pcloud_transformed.paint_uniform_color([0, 0, 1])  # blue
+    matrix = np.loadtxt(os.path.join(TMP_PATH, 'final_rigid_matrix.txt'))
     if visualize:
         o3d.visualization.draw_geometries(
             [pcloud_transformed, down_model, down_scene])
-        matrix = np.loadtxt(os.path.join(TMP_PATH, 'final_rigid_matrix.txt'))
         transformed = np.dot(model, matrix[:3, :3].T) + matrix[:3, 3].T
         pcloud_transformed.points = o3d.utility.Vector3dVector(transformed)
         pcloud_transformed.paint_uniform_color([0, 0, 1])  # blue
@@ -114,9 +123,9 @@ def run_pairwise_registration(i, j, visualize=False, icp_refine=False):
         threshold = 0.02
         trans_init = matrix
         t1 = time.time()
-        reg_p2p = o3d.registration.registration_icp(
+        reg_p2p = o3d.pipelines.registration.registration_icp(
             down_model, down_scene, threshold, trans_init,
-            o3d.registration.TransformationEstimationPointToPoint())
+            o3d.pipelines.registration.TransformationEstimationPointToPoint())
         t2 = time.time()
         print("ICP Run time : %s seconds" % (t2 - t1))
         print(reg_p2p)
@@ -159,8 +168,17 @@ def main():
     np.savetxt('./tmp/loung_expts_results.txt', o)
 
 
-import sys
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Testing script for running gmmreg on the Lounge RGB-D dataset.')
+    parser.add_argument(
+        '--data_path',
+        default='../data/lounge',
+        help='Directory containing the Lounge dataset (depth/ subfolder and lounge_trajectory.log).')
+    args = parser.parse_args()
+
+    _init_data(args.data_path)
+
     # Register just one pair, visualize point clouds before/after alignment.
     #run_pairwise_registration(1, 6, visualize=True)
     #run_pairwise_registration(20, 26, visualize=True)

--- a/expts/requirements.txt
+++ b/expts/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+scipy
+open3d
+opencv-python


### PR DESCRIPTION
- Multi-stage Dockerfile: Stage 1 builds C++ binary, Stage 2 sets up Python 3.12 with required packages; expts/ is mounted at runtime
- Makefile with targets: build, run-dragon, run-lounge, shell, clean
- Fix q_ij bug in dragon_expts.py (was q_i*q_i.inv(), always identity)
- Fix matrix used-before-assignment in lounge_expts.py when icp_refine=True
- Fix outdated Open3D API (o3d.registration -> o3d.pipelines.registration)
- Remove hardcoded DATA_PATH in lounge_expts.py; add --data_path CLI arg
- Remove module-level GT_POS/DEPTH_FILES init that crashed on import
- Clean up imports in dragon_expts.py; drop Python 2 ConfigParser fallback
- Add requirements.txt and README.md for the expts/ folder